### PR TITLE
fix: show next event in homepage, not newest

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -6,7 +6,18 @@ import { EventDetails } from "~/components/EventDetails";
 import { PageGrid } from "~/components/PageGrid";
 
 export const loader = async () => {
-	return json((await import("../data/events.json")).default[0]);
+	// This assumes the events are always in sorted order, newest first.
+	// Surely this assumption on undocumented data behavior will never come back to haunt us.
+	const events = (await import("../data/events.json")).map((event) => ({
+		...event,
+		date: new Date(event.date),
+	}));
+
+	// This assumes we'll always have a rebuild of the site after an event finishes.
+	// Surely this assumption tied to datetime logic will never come back to haunt us.
+	const now = new Date();
+
+	return json(events[events.findIndex((event) => now > event.date) - 1]);
 };
 
 export const meta: V2_MetaFunction = () => {
@@ -22,7 +33,7 @@ export default function Index() {
 				<>
 					<h2 className="larger">Next Jawn</h2>
 					<EventDetails
-						date={new Date(event.date[0])}
+						date={new Date(event.date)}
 						link={event.link}
 						linkText="Register Now"
 						location={event.location}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6
- [x] That issue was marked as [`status: accepting prs`](https://github.com/philly-js-club/philly-js-club-site/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/philly-js-club/philly-js-club-site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Documents some existing assumptions in data. Surely they will never come back to haunt us.